### PR TITLE
Add an error message for EigAparck when v0 is not set in the matrix-free case

### DIFF
--- a/src/EigSolver.jl
+++ b/src/EigSolver.jl
@@ -51,6 +51,9 @@ function (l::EigArpack)(J, nev::Int64)
 	if J isa AbstractMatrix
 		λ, ϕ, ncv = Arpack.eigs(J; nev = nev, which = l.which, sigma = l.sigma, l.kwargs...)
 	else
+                if !(:v0 in keys(l.kwargs))
+                    error("The v0 argument must be set for EigArpack in the matrix-free case")
+                end
 		N = length(l.kwargs[:v0])
 		T = eltype(l.kwargs[:v0])
 		Jmap = LinearMap{T}(J, N, N; ismutating = false)


### PR DESCRIPTION
A better solution would be to pass N and T but I understand it might be tricky.